### PR TITLE
Enable stricter ESLint rules and fix violations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,9 +8,9 @@
     "ecmaVersion": 12
   },
   "rules": {
-    "no-unused-vars": "off",
-    "no-undef": "off",
-    "no-useless-escape": "off",
-    "no-empty": "off"
+    "no-unused-vars": "error",
+    "no-undef": "error",
+    "no-useless-escape": "error",
+    "no-empty": "error"
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,25 +1,25 @@
 module.exports = [
   {
-    files: ['**/*.js'],
+    files: ["**/*.js"],
     languageOptions: {
       ecmaVersion: 2021,
-      sourceType: 'commonjs',
+      sourceType: "commonjs",
       globals: {
-        require: 'readonly',
-        module: 'readonly',
-        __dirname: 'readonly',
-        process: 'readonly',
-        console: 'readonly',
+        require: "readonly",
+        module: "readonly",
+        __dirname: "readonly",
+        process: "readonly",
+        console: "readonly",
       },
     },
     linterOptions: {
-      reportUnusedDisableDirectives: 'error',
+      reportUnusedDisableDirectives: "error",
     },
     rules: {
-      'no-unused-vars': 'off',
-      'no-undef': 'off',
-      'no-useless-escape': 'off',
-      'no-empty': 'off',
+      "no-unused-vars": "error",
+      "no-undef": "error",
+      "no-useless-escape": "error",
+      "no-empty": "error",
     },
   },
 ];

--- a/src/constructors.js
+++ b/src/constructors.js
@@ -1,3 +1,4 @@
+/* global document */
 const { CONFIG, CONSTRUCTOR_ABBREVIATIONS } = require("./config");
 const { updateConstructorSummaryData } = require("./summary");
 const { closePopup, emergencyClosePopup } = require("./utils");
@@ -64,7 +65,7 @@ async function extractConstructorListData(page) {
         // Store in global map for later reference
         const cleanConstructorName = constructorName
           .toLowerCase()
-          .replace(/[\s\-]/g, "");
+          .replace(/[\s-]/g, "");
         constructorListData.set(cleanConstructorName, constructorInfo);
 
         console.log(
@@ -187,7 +188,7 @@ async function extractConstructorDataEnhanced(page, listConstructorData) {
     const playerNameDiv = popup.querySelector(".si-player__name");
     if (playerNameDiv) {
       const playerText = playerNameDiv.textContent.trim();
-      constructorName = playerText.toLowerCase().replace(/[\s\-]/g, "");
+      constructorName = playerText.toLowerCase().replace(/[\s-]/g, "");
     }
 
     // Extract value, season points, and percentage picked

--- a/src/drivers.js
+++ b/src/drivers.js
@@ -1,5 +1,10 @@
+/* global document */
 const { CONFIG, DRIVER_ABBREVIATIONS, TEAM_SWAP_DRIVERS } = require("./config");
-const { updateSummaryData } = require("./summary");
+const {
+  updateSummaryData,
+  summaryData,
+  constructorSummaryData,
+} = require("./summary");
 const { closePopup, emergencyClosePopup } = require("./utils");
 
 const RACE_ORDER_MAP = new Map();

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,6 @@ const {
   processAllDrivers,
   mergeTeamSwapDrivers,
   driverBreakdowns,
-  RACE_ORDER_MAP,
 } = require("./drivers");
 const {
   extractConstructorListData,
@@ -92,7 +91,9 @@ async function saveResults() {
   try {
     await fs.rm(versionFolder, { recursive: true, force: true });
     await fs.rm(latestFolder, { recursive: true, force: true });
-  } catch (e) {}
+  } catch (e) {
+    console.error("⚠️ Error removing output directories:", e.message);
+  }
 
   await fs.mkdir(versionedOutputDir, { recursive: true });
   await fs.mkdir(versionedConstructorDir, { recursive: true });
@@ -102,7 +103,7 @@ async function saveResults() {
   await fs.mkdir(latestConstructorDir, { recursive: true });
   await fs.mkdir(latestSummaryDir, { recursive: true });
 
-  for (const [driverId, driverData] of driverBreakdowns) {
+  for (const [, driverData] of driverBreakdowns) {
     const filename = `${driverData.abbreviation}.json`;
     const versionedFilepath = path.join(versionedOutputDir, filename);
     const latestFilepath = path.join(latestOutputDir, filename);
@@ -117,7 +118,7 @@ async function saveResults() {
     );
   }
 
-  for (const [constructorId, constructorData] of constructorBreakdowns) {
+  for (const [, constructorData] of constructorBreakdowns) {
     const filename = `${constructorData.abbreviation}.json`;
     const versionedFilepath = path.join(versionedConstructorDir, filename);
     const latestFilepath = path.join(latestConstructorDir, filename);

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,9 @@ async function closePopup(page) {
       await page.waitForTimeout(CONFIG.DELAYS.POPUP_CLOSE);
       return;
     }
-  } catch (e) {}
+  } catch (e) {
+    // Ignore errors when attempting to close the popup via button
+  }
   await page.keyboard.press("Escape");
   await page.waitForTimeout(CONFIG.DELAYS.POPUP_CLOSE);
 }
@@ -18,7 +20,9 @@ async function emergencyClosePopup(page) {
     await page.keyboard.press("Escape");
     await page.keyboard.press("Escape");
     await page.waitForTimeout(1000);
-  } catch (e) {}
+  } catch (e) {
+    // Ignore errors when attempting emergency close
+  }
 }
 
 module.exports = { closePopup, emergencyClosePopup };

--- a/tests/ordering.test.js
+++ b/tests/ordering.test.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+/* global describe, test, expect */
 const fs = require("fs").promises;
 const os = require("os");
 const path = require("path");


### PR DESCRIPTION
## Summary
- enforce `no-unused-vars`, `no-undef`, `no-useless-escape`, and `no-empty` as errors
- resolve resulting lint issues across source and tests
- add logging for directory cleanup failures

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcbb439060832a822827a9d56ad856