### PR TITLE
Use DOM structure to detect list rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A comprehensive web scraper for extracting F1 Fantasy driver data from the offic
 - **Smart File Organization**: Saves individual files as `{ABBREVIATION}.json` (e.g., `NOR.json`, `TSU.json`)
 - **Comprehensive Summaries**: Multiple summary files for different analysis needs
 - **Dynamic Race Detection**: Automatically determines race order from the website
+- **Structure-Based Row Detection**: Identifies driver and constructor entries by page structure instead of hard-coded name lists
 - **Error Handling**: Robust error handling with popup management and retry logic
 
 ## 🚀 Quick Start

--- a/src/constructors.js
+++ b/src/constructors.js
@@ -15,19 +15,6 @@ async function extractConstructorListData(page) {
     'div[class*="si-stats__list-item"]',
   );
   const validConstructors = [];
-  const constructorNames = [
-    "MCLAREN",
-    "RED BULL",
-    "FERRARI",
-    "MERCEDES",
-    "ASTON MARTIN",
-    "ALPINE",
-    "HAAS",
-    "WILLIAMS",
-    "KICK SAUBER",
-    "RB",
-    "RACING BULLS",
-  ];
 
   console.log(`📋 Analyzing ${constructorElements.length} list elements...`);
 
@@ -40,15 +27,14 @@ async function extractConstructorListData(page) {
 
       if (!positionText) continue;
 
-      // Check if this is a constructor row
-      const hasConstructorName = constructorNames.some((name) =>
-        positionText.toUpperCase().includes(name),
-      );
       const positionMatch = positionText.trim().match(/^(\d+)/);
+      const costValid = /\d/.test(costText || "");
+      const pointsValid = /\d/.test(pointsText || "");
+      const namePart = positionText.replace(/^\d+/, "").trim();
 
-      if (hasConstructorName && positionMatch) {
+      if (positionMatch && costValid && pointsValid && namePart) {
         const position = parseInt(positionMatch[1]);
-        const constructorName = positionText.replace(/^\d+/, "").trim();
+        const constructorName = namePart;
 
         const constructorInfo = {
           element: constructorElements[i],

--- a/src/drivers.js
+++ b/src/drivers.js
@@ -21,35 +21,6 @@ async function extractDriverListData(page) {
 
   const driverElements = await page.$$('div[class*="si-stats__list-item"]');
   const validDrivers = [];
-  const driverSurnames = [
-    "NORRIS",
-    "PIASTRI",
-    "VERSTAPPEN",
-    "RUSSELL",
-    "HAMILTON",
-    "LECLERC",
-    "SAINZ",
-    "PEREZ",
-    "ALONSO",
-    "STROLL",
-    "GASLY",
-    "OCON",
-    "HULKENBERG",
-    "MAGNUSSEN",
-    "BOTTAS",
-    "ZHOU",
-    "ALBON",
-    "SARGEANT",
-    "TSUNODA",
-    "RICCIARDO",
-    "ANTONELLI",
-    "BEARMAN",
-    "HADJAR",
-    "BORTOLETO",
-    "LAWSON",
-    "COLAPINTO",
-    "DOOHAN",
-  ];
 
   console.log(`📋 Analyzing ${driverElements.length} list elements...`);
 
@@ -63,15 +34,14 @@ async function extractDriverListData(page) {
 
       if (!positionText) continue;
 
-      // Check if this is a driver row
-      const hasDriverName = driverSurnames.some((surname) =>
-        positionText.includes(surname),
-      );
       const positionMatch = positionText.trim().match(/^(\d+)/);
+      const costValid = /\d/.test(costText || "");
+      const pointsValid = /\d/.test(pointsText || "");
+      const namePart = positionText.replace(/^\d+/, "").trim();
 
-      if (hasDriverName && positionMatch) {
+      if (positionMatch && costValid && pointsValid && namePart) {
         const position = parseInt(positionMatch[1]);
-        const driverName = positionText.replace(/^\d+/, "").trim();
+        const driverName = namePart;
 
         const driverInfo = {
           element: driverElements[i],

--- a/tests/listExtraction.test.js
+++ b/tests/listExtraction.test.js
@@ -1,0 +1,57 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach */
+const { extractDriverListData, driverListData } = require("../src/drivers");
+const {
+  extractConstructorListData,
+  constructorListData,
+} = require("../src/constructors");
+
+function createElement(text) {
+  return {
+    text,
+    async textContent() {
+      return this.text;
+    },
+  };
+}
+
+describe("list data extraction", () => {
+  beforeEach(() => {
+    driverListData.clear();
+    constructorListData.clear();
+  });
+
+  test("extractDriverListData detects driver rows based on structure", async () => {
+    const elements = [
+      createElement("1 Random Driver"),
+      createElement("Some Team"),
+      createElement("20.0"),
+      createElement("100"),
+      // invalid row missing cost
+      createElement("2 Another Driver"),
+      createElement("Other Team"),
+      createElement(""),
+      createElement("90"),
+    ];
+    const page = { $$: async () => elements };
+    const drivers = await extractDriverListData(page);
+    expect(drivers).toHaveLength(1);
+    expect(drivers[0].name).toBe("Random Driver");
+  });
+
+  test("extractConstructorListData detects constructor rows based on structure", async () => {
+    const elements = [
+      createElement("1 Unknown Team"),
+      createElement("20.1"),
+      createElement("200"),
+      // invalid row missing points
+      createElement("2 Another Team"),
+      createElement("15.0"),
+      createElement(""),
+    ];
+    const page = { $$: async () => elements };
+    const constructors = await extractConstructorListData(page);
+    expect(constructors).toHaveLength(1);
+    expect(constructors[0].name).toBe("Unknown Team");
+  });
+});


### PR DESCRIPTION
## Summary
- detect driver list entries by verifying position, cost, and points fields instead of matching predefined surnames
- detect constructor list entries via structural checks and remove hard-coded constructor names
- add tests covering pages with unknown driver and constructor names
- document structure-based row detection in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcbe077d10832aab8b806d81f4f179