### PR TITLE
Refactor session event handling with mapping tables

### DIFF
--- a/tests/eventMapping.test.js
+++ b/tests/eventMapping.test.js
@@ -1,0 +1,80 @@
+/* eslint-env jest */
+/* global describe, test, expect */
+const { extractSessionDataEnhanced } = require("../src/drivers");
+const { extractConstructorSessionData } = require("../src/constructors");
+
+function createCell(text, negative = false) {
+  return {
+    async textContent() {
+      return text;
+    },
+    async evaluate(fn) {
+      return fn({
+        classList: {
+          contains: (cls) => negative && cls === "si-negative",
+        },
+      });
+    },
+  };
+}
+
+function createRow(eventName, points, negative = false) {
+  const cells = [
+    createCell(eventName),
+    createCell(""),
+    createCell(points, negative),
+  ];
+  return {
+    async $$() {
+      return cells;
+    },
+  };
+}
+
+function createRaceElement(rows, sprint = false) {
+  const table = {
+    async $$() {
+      return rows;
+    },
+  };
+  return {
+    async $$(selector) {
+      if (selector === "table.si-tbl") return [table];
+      return [];
+    },
+    async $(selector) {
+      if (selector === '.si-tabs__wrap button:has-text("Sprint")')
+        return sprint ? {} : null;
+      return null;
+    },
+  };
+}
+
+describe("event mapping", () => {
+  test("driver events map to the correct session sections", async () => {
+    const rows = [
+      createRow("Race Fastest Lap", "5"),
+      createRow("Sprint Fastest Lap", "2"),
+      createRow("Unknown Event", "1"),
+    ];
+    const element = createRaceElement(rows, true);
+    const data = await extractSessionDataEnhanced(element);
+    expect(data.race.fastestLap).toBe(5);
+    expect(data.sprint.fastestLap).toBe(2);
+    expect(data.race.dotd).toBe(0);
+  });
+
+  test("constructor events use mapping table and ignore unknown", async () => {
+    const rows = [
+      createRow("Pit Stop", "1"),
+      createRow("Pit Stop", "1"),
+      createRow("Both drivers reach Q3", "3"),
+      createRow("Random Unknown", "4"),
+    ];
+    const element = createRaceElement(rows);
+    const data = await extractConstructorSessionData(element);
+    expect(data.race.pitStopBonus).toBe(2);
+    expect(data.qualifying.q3Bonus).toBe(3);
+    expect(data.race.position).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Map normalized driver event strings to session sections and fields
- Map constructor session events and replace conditional parsing with table lookup
- Add tests validating event mapping and handling of unknown events

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcd0e41050832ab0d0123126f8bc39