### PR TITLE
test: cover popup utilities

### DIFF
--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,77 @@
+/* eslint-env jest */
+/* global jest, describe, test, expect */
+const { closePopup, emergencyClosePopup } = require("../src/utils");
+const { CONFIG } = require("../src/config");
+
+describe("closePopup", () => {
+  test("clicks close button when available", async () => {
+    const click = jest.fn();
+    const page = {
+      $: jest.fn().mockResolvedValue({ click }),
+      keyboard: { press: jest.fn() },
+      waitForTimeout: jest.fn(),
+    };
+
+    await closePopup(page);
+
+    expect(page.$).toHaveBeenCalledWith(".si-popup__close");
+    expect(click).toHaveBeenCalled();
+    expect(page.keyboard.press).not.toHaveBeenCalled();
+    expect(page.waitForTimeout).toHaveBeenCalledWith(CONFIG.DELAYS.POPUP_CLOSE);
+  });
+
+  test("presses escape when close button missing", async () => {
+    const page = {
+      $: jest.fn().mockResolvedValue(null),
+      keyboard: { press: jest.fn() },
+      waitForTimeout: jest.fn(),
+    };
+
+    await closePopup(page);
+
+    expect(page.$).toHaveBeenCalledWith(".si-popup__close");
+    expect(page.keyboard.press).toHaveBeenCalledWith("Escape");
+    expect(page.waitForTimeout).toHaveBeenCalledWith(CONFIG.DELAYS.POPUP_CLOSE);
+  });
+
+  test("presses escape when querying close button fails", async () => {
+    const page = {
+      $: jest.fn().mockRejectedValue(new Error("fail")),
+      keyboard: { press: jest.fn() },
+      waitForTimeout: jest.fn(),
+    };
+
+    await closePopup(page);
+
+    expect(page.$).toHaveBeenCalled();
+    expect(page.keyboard.press).toHaveBeenCalledWith("Escape");
+    expect(page.waitForTimeout).toHaveBeenCalledWith(CONFIG.DELAYS.POPUP_CLOSE);
+  });
+});
+
+describe("emergencyClosePopup", () => {
+  test("presses escape twice and waits", async () => {
+    const page = {
+      keyboard: { press: jest.fn() },
+      waitForTimeout: jest.fn(),
+    };
+
+    await emergencyClosePopup(page);
+
+    expect(page.keyboard.press).toHaveBeenCalledTimes(2);
+    expect(page.keyboard.press).toHaveBeenCalledWith("Escape");
+    expect(page.waitForTimeout).toHaveBeenCalledWith(1000);
+  });
+
+  test("swallows errors from keyboard presses", async () => {
+    const page = {
+      keyboard: { press: jest.fn().mockRejectedValue(new Error("fail")) },
+      waitForTimeout: jest.fn(),
+    };
+
+    await emergencyClosePopup(page);
+
+    expect(page.keyboard.press).toHaveBeenCalledWith("Escape");
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive jest tests for popup utilities

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68bcdf1d7184832a85305c78b34daf16