### PR TITLE
Expand tests and document coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ npm run lint
 npm test
 ```
 
+## Test Coverage
+
+Current line coverage: 38.18% (measured with `npx jest --coverage`).
+
 ### Debug logging
 
 Verbose logging for some utilities can be toggled with a `DEBUG` flag. Set it to `true` to print additional output, for example:

--- a/tests/summaryAccumulation.test.js
+++ b/tests/summaryAccumulation.test.js
@@ -1,0 +1,59 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach */
+const {
+  updateSummaryData,
+  summaryData,
+  updateConstructorSummaryData,
+  constructorSummaryData,
+} = require("../src/summary");
+
+describe("summary data aggregation", () => {
+  beforeEach(() => {
+    summaryData.clear();
+    constructorSummaryData.clear();
+  });
+
+  test("updateSummaryData aggregates driver race results", () => {
+    const driver1 = {
+      abbreviation: "HAM",
+      races: [
+        { round: "1", raceName: "Bahrain", totalPoints: 10 },
+        { round: "2", raceName: "Saudi", totalPoints: 8 },
+      ],
+    };
+    const driver2 = {
+      abbreviation: "VER",
+      races: [{ round: "1", raceName: "Bahrain", totalPoints: 25 }],
+    };
+    updateSummaryData(driver1);
+    updateSummaryData(driver2);
+    const race1 = summaryData.get("1");
+    const race2 = summaryData.get("2");
+    expect(race1.raceName).toBe("Bahrain");
+    expect(race1.drivers.get("HAM")).toBe(10);
+    expect(race1.drivers.get("VER")).toBe(25);
+    expect(race2.drivers.get("HAM")).toBe(8);
+  });
+
+  test("updateConstructorSummaryData aggregates constructor race results", () => {
+    const constructor1 = {
+      abbreviation: "MER",
+      races: [{ round: "1", raceName: "Bahrain", totalPoints: 35 }],
+    };
+    const constructor2 = {
+      abbreviation: "RED",
+      races: [
+        { round: "1", raceName: "Bahrain", totalPoints: 40 },
+        { round: "2", raceName: "Saudi", totalPoints: 44 },
+      ],
+    };
+    updateConstructorSummaryData(constructor1);
+    updateConstructorSummaryData(constructor2);
+    const race1 = constructorSummaryData.get("1");
+    const race2 = constructorSummaryData.get("2");
+    expect(race1.raceName).toBe("Bahrain");
+    expect(race1.constructors.get("MER")).toBe(35);
+    expect(race1.constructors.get("RED")).toBe(40);
+    expect(race2.constructors.get("RED")).toBe(44);
+  });
+});


### PR DESCRIPTION
## Summary
- add aggregation tests for summary utilities covering drivers and constructors
- document current line coverage in README

## Testing
- `npm run lint`
- `npm test`
- `npx jest --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68bcedc80518832abc6107c6b96d83f8