### PR TITLE
test: cover summary ordering helpers

### DIFF
--- a/tests/eventMapping.test.js
+++ b/tests/eventMapping.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-/* global describe, test, expect */
+/* global describe, test, expect, jest */
 const { extractSessionDataEnhanced } = require("../src/drivers");
 const { extractConstructorSessionData } = require("../src/constructors");
 const { applyEvent } = require("../src/eventMapper");
@@ -68,6 +68,17 @@ describe("applyEvent", () => {
     const sessionData = { race: { position: 0 } };
     applyEvent(sessionData, "Unknown Event", 4, DRIVER_EVENT_MAP);
     expect(sessionData.race.position).toBe(0);
+  });
+
+  test("logs unknown events", () => {
+    const sessionData = { race: {} };
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    applyEvent(sessionData, "Mystery", 1, DRIVER_EVENT_MAP);
+
+    expect(logSpy).toHaveBeenCalledWith("ℹ️ Unknown event: Mystery");
+
+    logSpy.mockRestore();
   });
 });
 

--- a/tests/summaryOrdering.test.js
+++ b/tests/summaryOrdering.test.js
@@ -1,0 +1,79 @@
+/* eslint-env jest */
+/* global describe, test, expect, jest */
+const fs = require("fs").promises;
+const os = require("os");
+const path = require("path");
+const {
+  getSortedRoundKeys,
+  fixWeekendSummaryOrdering,
+  fixConstructorWeekendSummaryOrdering,
+} = require("../src/summary");
+
+describe("summary ordering utilities", () => {
+  test("getSortedRoundKeys sorts numeric keys", () => {
+    const data = { 10: {}, 2: {}, 1: {} };
+    expect(getSortedRoundKeys(data)).toEqual(["1", "2", "10"]);
+  });
+
+  test("fixWeekendSummaryOrdering sorts rounds in file", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "summary-"));
+    const filePath = path.join(tmpDir, "driver.json");
+    const unsortedJson = '{"10":{"a":1},"2":{"a":2},"1":{"a":3}}';
+    await fs.writeFile(filePath, unsortedJson);
+
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    await fixWeekendSummaryOrdering(filePath);
+    logSpy.mockRestore();
+
+    const fixed = JSON.parse(await fs.readFile(filePath, "utf8"));
+    expect(Object.keys(fixed)).toEqual(["1", "2", "10"]);
+  });
+
+  test("fixConstructorWeekendSummaryOrdering supports debug logging", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "constructor-"));
+    const filePath = path.join(tmpDir, "constructor.json");
+    const unsortedJson = '{"3":{"b":1},"1":{"b":2}}';
+    await fs.writeFile(filePath, unsortedJson);
+
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    await fixConstructorWeekendSummaryOrdering(filePath, true);
+    logSpy.mockRestore();
+
+    const fixed = JSON.parse(await fs.readFile(filePath, "utf8"));
+    expect(Object.keys(fixed)).toEqual(["1", "3"]);
+  });
+
+  test("fixWeekendSummaryOrdering logs errors", async () => {
+    const readSpy = jest
+      .spyOn(fs, "readFile")
+      .mockRejectedValue(new Error("fail"));
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await fixWeekendSummaryOrdering("bad-path.json");
+
+    expect(errSpy).toHaveBeenCalledWith(
+      "❌ Error fixing driver weekend summary ordering:",
+      "fail",
+    );
+
+    readSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  test("fixConstructorWeekendSummaryOrdering logs errors", async () => {
+    const readSpy = jest
+      .spyOn(fs, "readFile")
+      .mockRejectedValue(new Error("oops"));
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await fixConstructorWeekendSummaryOrdering("bad-path.json");
+
+    expect(errSpy).toHaveBeenCalledWith(
+      "❌ Error fixing constructor weekend summary ordering:",
+      "oops",
+    );
+
+    readSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for getSortedRoundKeys
- verify fixWeekendSummaryOrdering and fixConstructorWeekendSummaryOrdering reorder files correctly and log errors on read failure
- ensure applyEvent logs unknown events

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcef2692c0832a825298853ce9802a