### PR TITLE
Handle essential cookie consent pop-up

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ const path = require("path");
 const { CONFIG } = require("./config");
 const { DriverScraper } = require("./drivers");
 const { ConstructorScraper } = require("./constructors");
+const { closePopup } = require("./utils");
 
 // Instantiate scrapers so their internal data structures can be reused
 const driverScraper = new DriverScraper();
@@ -33,6 +34,7 @@ async function main() {
     console.log(`📊 Target: ${CONFIG.DRIVER_URL}`);
     await page.goto(CONFIG.DRIVER_URL, { waitUntil: "load" });
     await page.waitForTimeout(CONFIG.DELAYS.PAGE_LOAD);
+    await closePopup(page);
 
     const driverElements = await driverScraper.extractListData(page);
     await driverScraper.processAll(page, driverElements);
@@ -40,6 +42,7 @@ async function main() {
     console.log(`📊 Target: ${CONFIG.CONSTRUCTOR_URL}`);
     await page.goto(CONFIG.CONSTRUCTOR_URL, { waitUntil: "load" });
     await page.waitForTimeout(CONFIG.DELAYS.PAGE_LOAD);
+    await closePopup(page);
 
     const constructorElements = await constructorScraper.extractListData(page);
     await constructorScraper.processAll(page, constructorElements);

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,27 @@ const { CONFIG } = require("./config");
 
 async function closePopup(page) {
   try {
+    const buttons = await page.$$("button");
+    for (const button of buttons) {
+      try {
+        const text = (await button.textContent())?.trim();
+        if (
+          /use essential cookies only/i.test(text) ||
+          /reject all/i.test(text)
+        ) {
+          await button.click();
+          await page.waitForTimeout(CONFIG.DELAYS.POPUP_CLOSE);
+          return;
+        }
+      } catch (e) {
+        // Ignore errors while checking cookie buttons
+      }
+    }
+  } catch (e) {
+    // Ignore errors when searching for cookie banner
+  }
+
+  try {
     const closeButton = await page.$(".si-popup__close");
     if (closeButton) {
       await closeButton.click();
@@ -11,6 +32,7 @@ async function closePopup(page) {
   } catch (e) {
     // Ignore errors when attempting to close the popup via button
   }
+
   await page.keyboard.press("Escape");
   await page.waitForTimeout(CONFIG.DELAYS.POPUP_CLOSE);
 }

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -4,9 +4,37 @@ const { closePopup, emergencyClosePopup } = require("../src/utils");
 const { CONFIG } = require("../src/config");
 
 describe("closePopup", () => {
+  test("clicks essential cookies button when available", async () => {
+    const click = jest.fn();
+    const page = {
+      $$: jest
+        .fn()
+        .mockResolvedValue([
+          {
+            textContent: jest
+              .fn()
+              .mockResolvedValue("Use essential cookies only"),
+            click,
+          },
+        ]),
+      $: jest.fn(),
+      keyboard: { press: jest.fn() },
+      waitForTimeout: jest.fn(),
+    };
+
+    await closePopup(page);
+
+    expect(page.$$).toHaveBeenCalledWith("button");
+    expect(click).toHaveBeenCalled();
+    expect(page.$).not.toHaveBeenCalled();
+    expect(page.keyboard.press).not.toHaveBeenCalled();
+    expect(page.waitForTimeout).toHaveBeenCalledWith(CONFIG.DELAYS.POPUP_CLOSE);
+  });
+
   test("clicks close button when available", async () => {
     const click = jest.fn();
     const page = {
+      $$: jest.fn().mockResolvedValue([]),
       $: jest.fn().mockResolvedValue({ click }),
       keyboard: { press: jest.fn() },
       waitForTimeout: jest.fn(),
@@ -22,6 +50,7 @@ describe("closePopup", () => {
 
   test("presses escape when close button missing", async () => {
     const page = {
+      $$: jest.fn().mockResolvedValue([]),
       $: jest.fn().mockResolvedValue(null),
       keyboard: { press: jest.fn() },
       waitForTimeout: jest.fn(),
@@ -36,6 +65,7 @@ describe("closePopup", () => {
 
   test("presses escape when querying close button fails", async () => {
     const page = {
+      $$: jest.fn().mockResolvedValue([]),
       $: jest.fn().mockRejectedValue(new Error("fail")),
       keyboard: { press: jest.fn() },
       waitForTimeout: jest.fn(),


### PR DESCRIPTION
## Summary
- Close cookie consent banner by selecting "Use essential cookies only"
- Call popup handler after visiting driver and constructor pages
- Test popup handler for cookie banner interaction

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd1fbd1398832ab1d47a24ae29f5c5