### PR TITLE
Handle cookie permissions modal before scraping

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,35 @@ const { CONFIG } = require("./config");
 
 async function closePopup(page) {
   try {
+    const cookieHeading = await page.$(
+      'h2:has-text("YOUR CHOICES REGARDING COOKIES ON THIS SITE")',
+    );
+    if (cookieHeading) {
+      const manageButton = await page.$(
+        'button[aria-label="No, manage settings"]',
+      );
+      if (manageButton) {
+        await manageButton.click();
+        try {
+          await page.waitForSelector('h2:has-text("MANAGE YOUR CHOICES")', {
+            timeout: CONFIG.DELAYS.POPUP_WAIT,
+          });
+        } catch (e) {
+          // ignore timeout waiting for manage choices modal
+        }
+        const rejectButton = await page.$('button[aria-label="Reject all"]');
+        if (rejectButton) {
+          await rejectButton.click();
+          await page.waitForTimeout(CONFIG.DELAYS.POPUP_CLOSE);
+          return;
+        }
+      }
+    }
+  } catch (e) {
+    // Ignore errors when handling cookie permissions modal
+  }
+
+  try {
     const buttons = await page.$$("button");
     for (const button of buttons) {
       try {


### PR DESCRIPTION
## Summary
- ensure scraper dismisses cookie consent by clicking **No, manage settings** then **Reject all**
- test closePopup with new cookie consent flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd22c5238c832a86a80f2407097165