### PR TITLE
Improve cookie banner handling

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,69 +1,113 @@
 const { CONFIG } = require("./config");
 
-async function closePopup(page) {
+async function closePopup(page, delays = CONFIG.DELAYS) {
+  // Helper to click a visible button by accessible name
+  const clickByRole = async (scope, nameRe, timeout = 2000) => {
+    const btn = scope
+      .getByRole("button", { name: nameRe, exact: false })
+      .first();
+    await btn.waitFor({ state: "visible", timeout });
+    await btn.click();
+    await page.waitForTimeout(delays.POPUP_CLOSE);
+    return true;
+  };
+
+  // 1) Sourcepoint iframe
   try {
-    const cookieHeading = await page.$(
-      'h2:has-text("YOUR CHOICES REGARDING COOKIES ON THIS SITE")',
+    const spFrame = page.frameLocator(
+      'iframe[title*="SP Consent" i], iframe[id^="sp_message_iframe"]',
     );
-    if (cookieHeading) {
-      const manageButton = await page.$(
-        'button[aria-label="No, manage settings"]',
+    if (
+      await clickByRole(
+        spFrame,
+        /reject.*all|only.*essential|essential.*only/i,
+        3000,
+      )
+    )
+      return;
+    if (await clickByRole(spFrame, /manage|settings|options/i, 1500)) {
+      await clickByRole(
+        spFrame,
+        /reject.*all|save.*without.*consent|confirm choices/i,
+        3000,
       );
-      if (manageButton) {
-        await manageButton.click();
-        try {
-          await page.waitForSelector('h2:has-text("MANAGE YOUR CHOICES")', {
-            timeout: CONFIG.DELAYS.POPUP_WAIT,
-          });
-        } catch (e) {
-          // ignore timeout waiting for manage choices modal
-        }
-        const rejectButton = await page.$('button[aria-label="Reject all"]');
-        if (rejectButton) {
-          await rejectButton.click();
-          await page.waitForTimeout(CONFIG.DELAYS.POPUP_CLOSE);
-          return;
-        }
-      }
-    }
-  } catch (e) {
-    // Ignore errors when handling cookie permissions modal
-  }
-
-  try {
-    const buttons = await page.$$("button");
-    for (const button of buttons) {
-      try {
-        const text = (await button.textContent())?.trim();
-        if (
-          /use essential cookies only/i.test(text) ||
-          /reject all/i.test(text)
-        ) {
-          await button.click();
-          await page.waitForTimeout(CONFIG.DELAYS.POPUP_CLOSE);
-          return;
-        }
-      } catch (e) {
-        // Ignore errors while checking cookie buttons
-      }
-    }
-  } catch (e) {
-    // Ignore errors when searching for cookie banner
-  }
-
-  try {
-    const closeButton = await page.$(".si-popup__close");
-    if (closeButton) {
-      await closeButton.click();
-      await page.waitForTimeout(CONFIG.DELAYS.POPUP_CLOSE);
       return;
     }
-  } catch (e) {
-    // Ignore errors when attempting to close the popup via button
+  } catch (_) {
+    /* ignore */
   }
 
-  await page.keyboard.press("Escape");
-  await page.waitForTimeout(CONFIG.DELAYS.POPUP_CLOSE);
+  // 2) OneTrust patterns
+  try {
+    const otFrame = page.frameLocator(
+      'iframe[title*="OneTrust" i], iframe[id^="ot-sdk-ui"]',
+    );
+    const otSelectors = [
+      "#onetrust-reject-all-handler",
+      'button[aria-label*="Reject" i]',
+      'button:has-text("Reject All")',
+      'button:has-text("Use essential cookies only")',
+    ].join(", ");
+    const otInFrame = otFrame.locator(otSelectors).first();
+    if (await otInFrame.isVisible({ timeout: 2000 })) {
+      await otInFrame.click();
+      await page.waitForTimeout(delays.POPUP_CLOSE);
+      return;
+    }
+  } catch (_) {
+    /* ignore */
+  }
+  try {
+    const otTop = page
+      .locator(
+        [
+          "#onetrust-reject-all-handler",
+          'button[aria-label*="Reject" i]',
+          'button:has-text("Reject All")',
+          'button:has-text("Use essential cookies only")',
+        ].join(", "),
+      )
+      .first();
+    if (await otTop.isVisible({ timeout: 2000 })) {
+      await otTop.click();
+      await page.waitForTimeout(delays.POPUP_CLOSE);
+      return;
+    }
+  } catch (_) {
+    /* ignore */
+  }
+
+  // 3) Generic accessible fallback
+  try {
+    if (
+      await clickByRole(
+        page,
+        /reject.*all|only.*essential|essential.*only/i,
+        1500,
+      )
+    )
+      return;
+
+    if (await clickByRole(page, /manage|settings|options/i, 1500)) {
+      await clickByRole(
+        page,
+        /reject.*all|save.*without.*consent|confirm choices/i,
+        3000,
+      );
+      return;
+    }
+  } catch (_) {
+    /* ignore */
+  }
+
+  // 4) Last resort: ESC twice
+  try {
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(delays.POPUP_CLOSE);
+  } catch (_) {
+    /* ignore */
+  }
 }
 
 async function emergencyClosePopup(page) {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -4,119 +4,104 @@ const { closePopup, emergencyClosePopup } = require("../src/utils");
 const { CONFIG } = require("../src/config");
 
 describe("closePopup", () => {
-  test("handles manage settings cookie modal", async () => {
-    const manageClick = jest.fn();
-    const rejectClick = jest.fn();
+  test("clicks reject in Sourcepoint frame when available", async () => {
+    const button = {
+      waitFor: jest.fn().mockResolvedValue(),
+      click: jest.fn().mockResolvedValue(),
+    };
+    const spFrame = {
+      getByRole: jest.fn().mockReturnValue({ first: () => button }),
+    };
     const page = {
-      $$: jest.fn().mockResolvedValue([]),
-      $: jest.fn().mockImplementation((selector) => {
-        if (
-          selector ===
-          'h2:has-text("YOUR CHOICES REGARDING COOKIES ON THIS SITE")'
-        ) {
-          return Promise.resolve({});
-        }
-        if (selector === 'button[aria-label="No, manage settings"]') {
-          return Promise.resolve({ click: manageClick });
-        }
-        if (selector === 'button[aria-label="Reject all"]') {
-          return Promise.resolve({ click: rejectClick });
-        }
-        if (selector === ".si-popup__close") {
-          return Promise.resolve(null);
-        }
-        return Promise.resolve(null);
-      }),
-      waitForSelector: jest.fn().mockResolvedValue(),
-      keyboard: { press: jest.fn() },
+      frameLocator: jest.fn().mockReturnValueOnce(spFrame),
       waitForTimeout: jest.fn(),
+      keyboard: { press: jest.fn() },
+      locator: jest.fn(),
+      getByRole: jest.fn(),
     };
 
     await closePopup(page);
 
-    expect(page.$).toHaveBeenCalledWith(
-      'h2:has-text("YOUR CHOICES REGARDING COOKIES ON THIS SITE")',
-    );
-    expect(manageClick).toHaveBeenCalled();
-    expect(page.waitForSelector).toHaveBeenCalledWith(
-      'h2:has-text("MANAGE YOUR CHOICES")',
-      { timeout: CONFIG.DELAYS.POPUP_WAIT },
-    );
-    expect(rejectClick).toHaveBeenCalled();
+    expect(page.frameLocator).toHaveBeenCalled();
+    expect(button.click).toHaveBeenCalled();
     expect(page.waitForTimeout).toHaveBeenCalledWith(CONFIG.DELAYS.POPUP_CLOSE);
   });
-  test("clicks essential cookies button when available", async () => {
-    const click = jest.fn();
+
+  test("clicks accessible reject button when no iframe matches", async () => {
+    const failingButton = {
+      waitFor: jest.fn().mockRejectedValue(new Error("no")),
+      click: jest.fn(),
+    };
+    const spFrame = {
+      getByRole: jest.fn().mockReturnValue({ first: () => failingButton }),
+    };
+    const otFrame = {
+      locator: jest
+        .fn()
+        .mockReturnValue({
+          first: () => ({ isVisible: jest.fn().mockResolvedValue(false) }),
+        }),
+    };
+    const genericButton = {
+      waitFor: jest.fn().mockResolvedValue(),
+      click: jest.fn().mockResolvedValue(),
+    };
     const page = {
-      $$: jest.fn().mockResolvedValue([
-        {
-          textContent: jest
-            .fn()
-            .mockResolvedValue("Use essential cookies only"),
-          click,
-        },
-      ]),
-      $: jest.fn().mockResolvedValue(null),
-      keyboard: { press: jest.fn() },
+      frameLocator: jest
+        .fn()
+        .mockReturnValueOnce(spFrame)
+        .mockReturnValueOnce(otFrame),
+      locator: jest
+        .fn()
+        .mockReturnValue({
+          first: () => ({ isVisible: jest.fn().mockResolvedValue(false) }),
+        }),
+      getByRole: jest.fn().mockReturnValue({ first: () => genericButton }),
       waitForTimeout: jest.fn(),
+      keyboard: { press: jest.fn() },
     };
 
     await closePopup(page);
 
-    expect(page.$$).toHaveBeenCalledWith("button");
-    expect(click).toHaveBeenCalled();
+    expect(page.getByRole).toHaveBeenCalled();
+    expect(genericButton.click).toHaveBeenCalled();
     expect(page.keyboard.press).not.toHaveBeenCalled();
     expect(page.waitForTimeout).toHaveBeenCalledWith(CONFIG.DELAYS.POPUP_CLOSE);
   });
 
-  test("clicks close button when available", async () => {
-    const click = jest.fn();
+  test("presses escape when no buttons are found", async () => {
+    const failingButton = {
+      waitFor: jest.fn().mockRejectedValue(new Error("no")),
+      click: jest.fn(),
+    };
+    const spFrame = {
+      getByRole: jest.fn().mockReturnValue({ first: () => failingButton }),
+    };
+    const otFrame = {
+      locator: jest
+        .fn()
+        .mockReturnValue({
+          first: () => ({ isVisible: jest.fn().mockResolvedValue(false) }),
+        }),
+    };
     const page = {
-      $$: jest.fn().mockResolvedValue([]),
-      $: jest.fn().mockImplementation((selector) => {
-        if (selector === ".si-popup__close") {
-          return Promise.resolve({ click });
-        }
-        return Promise.resolve(null);
-      }),
-      keyboard: { press: jest.fn() },
+      frameLocator: jest
+        .fn()
+        .mockReturnValueOnce(spFrame)
+        .mockReturnValueOnce(otFrame),
+      locator: jest
+        .fn()
+        .mockReturnValue({
+          first: () => ({ isVisible: jest.fn().mockResolvedValue(false) }),
+        }),
+      getByRole: jest.fn().mockReturnValue({ first: () => failingButton }),
       waitForTimeout: jest.fn(),
+      keyboard: { press: jest.fn() },
     };
 
     await closePopup(page);
 
-    expect(page.$).toHaveBeenCalledWith(".si-popup__close");
-    expect(click).toHaveBeenCalled();
-    expect(page.keyboard.press).not.toHaveBeenCalled();
-    expect(page.waitForTimeout).toHaveBeenCalledWith(CONFIG.DELAYS.POPUP_CLOSE);
-  });
-
-  test("presses escape when close button missing", async () => {
-    const page = {
-      $$: jest.fn().mockResolvedValue([]),
-      $: jest.fn().mockResolvedValue(null),
-      keyboard: { press: jest.fn() },
-      waitForTimeout: jest.fn(),
-    };
-
-    await closePopup(page);
-
-    expect(page.$).toHaveBeenCalledWith(".si-popup__close");
-    expect(page.keyboard.press).toHaveBeenCalledWith("Escape");
-    expect(page.waitForTimeout).toHaveBeenCalledWith(CONFIG.DELAYS.POPUP_CLOSE);
-  });
-
-  test("presses escape when querying close button fails", async () => {
-    const page = {
-      $$: jest.fn().mockResolvedValue([]),
-      $: jest.fn().mockRejectedValue(new Error("fail")),
-      keyboard: { press: jest.fn() },
-      waitForTimeout: jest.fn(),
-    };
-
-    await closePopup(page);
-
-    expect(page.$).toHaveBeenCalled();
+    expect(page.keyboard.press).toHaveBeenCalledTimes(2);
     expect(page.keyboard.press).toHaveBeenCalledWith("Escape");
     expect(page.waitForTimeout).toHaveBeenCalledWith(CONFIG.DELAYS.POPUP_CLOSE);
   });


### PR DESCRIPTION
## Summary
- enhance popup utility with Sourcepoint and OneTrust support using accessible roles
- add coverage for iframe, direct button and escape fallback behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd3e977e24832aadfd3d4c6a259ce9