### PR TITLE
Graceful fallback when close button missing

### DIFF
--- a/src/drivers/index.js
+++ b/src/drivers/index.js
@@ -83,10 +83,23 @@ class DriverScraper {
           raceOrder++;
         }
       }
-      await popup.$eval("button.si-popup__close", (btn) => btn.click());
+      const closeBtn = await popup.$(
+        'button.si-popup__close, button[aria-label*="close" i]',
+      );
+      if (closeBtn) {
+        await closeBtn.click();
+      } else {
+        await page.keyboard.press("Escape");
+      }
       await page.waitForTimeout(CONFIG.DELAYS.POPUP_CLOSE);
     } catch (err) {
       console.log(`⚠️  Unable to establish race order: ${err.message}`);
+      try {
+        await page.keyboard.press("Escape");
+        await page.waitForTimeout(CONFIG.DELAYS.POPUP_CLOSE);
+      } catch (_) {
+        /* ignore */
+      }
     }
   }
 

--- a/tests/establishRaceOrder.test.js
+++ b/tests/establishRaceOrder.test.js
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+/* global describe, test, expect, jest */
+const { DriverScraper } = require("../src/drivers");
+const { CONFIG } = require("../src/config");
+
+describe("DriverScraper.establishRaceOrder", () => {
+  test("falls back to Escape when close button is missing", async () => {
+    const scraper = new DriverScraper();
+    const driverElements = [{ element: { click: jest.fn() } }];
+
+    const raceNameElement = {
+      textContent: jest.fn().mockResolvedValue("Bahrain GP"),
+    };
+    const accordionItem = {
+      $: jest.fn().mockResolvedValue(raceNameElement),
+    };
+    const popup = {
+      $$: jest.fn().mockResolvedValue([accordionItem]),
+      $: jest.fn().mockResolvedValue(null),
+    };
+    const page = {
+      waitForSelector: jest.fn().mockResolvedValue(),
+      $: jest.fn().mockResolvedValue(popup),
+      waitForTimeout: jest.fn().mockResolvedValue(),
+      keyboard: { press: jest.fn().mockResolvedValue() },
+    };
+
+    await scraper.establishRaceOrder(page, driverElements);
+    expect(scraper.getRaceOrderMap().get("Bahrain GP")).toBe("1");
+    expect(page.keyboard.press).toHaveBeenCalledWith("Escape");
+    expect(page.waitForTimeout).toHaveBeenCalledWith(CONFIG.DELAYS.POPUP_CLOSE);
+  });
+});


### PR DESCRIPTION
## Summary
- Improve driver race order scraper to handle missing popup close buttons
- Add regression test ensuring fallback to Escape key

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd3ff4f938832ab5b2e402b3ace96a