### PR TITLE
Fix DEBUG flag handling for constructor summary ordering

### DIFF
--- a/src/summary.js
+++ b/src/summary.js
@@ -1,5 +1,9 @@
 const fs = require("fs").promises;
 
+// Capture the DEBUG flag at module load time so later changes to
+// process.env.DEBUG by dependencies don't affect logging behavior.
+const DEBUG_ENABLED = process.env.DEBUG === "true";
+
 const summaryData = new Map();
 const constructorSummaryData = new Map();
 
@@ -45,7 +49,7 @@ async function fixWeekendSummaryOrdering(filePath) {
  */
 async function fixConstructorWeekendSummaryOrdering(
   filePath,
-  debug = process.env.DEBUG === "true",
+  debug = DEBUG_ENABLED,
 ) {
   try {
     const fileContent = await fs.readFile(filePath, "utf8");

--- a/tests/summaryOrdering.test.js
+++ b/tests/summaryOrdering.test.js
@@ -43,6 +43,30 @@ describe("summary ordering utilities", () => {
     expect(Object.keys(fixed)).toEqual(["1", "3"]);
   });
 
+  test("fixConstructorWeekendSummaryOrdering uses DEBUG env variable", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "constructor-env-"));
+    const filePath = path.join(tmpDir, "constructor.json");
+    const unsortedJson = '{"3":{"b":1},"1":{"b":2}}';
+    await fs.writeFile(filePath, unsortedJson);
+
+    const originalEnv = process.env.DEBUG;
+    process.env.DEBUG = "true";
+    jest.resetModules();
+    const {
+      fixConstructorWeekendSummaryOrdering: fn,
+    } = require("../src/summary");
+    process.env.DEBUG = "false";
+
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    await fn(filePath);
+    const messages = logSpy.mock.calls.map((call) => call[0]);
+    expect(messages).toContainEqual(
+      expect.stringContaining("Keys in original file"),
+    );
+    logSpy.mockRestore();
+    process.env.DEBUG = originalEnv;
+  });
+
   test("fixWeekendSummaryOrdering logs errors", async () => {
     const readSpy = jest
       .spyOn(fs, "readFile")


### PR DESCRIPTION
## Summary
- capture DEBUG environment variable at module load to ensure logging can be toggled reliably
- add tests to verify DEBUG env support and prevent regressions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd433302b8832abe154528b8397e96