### PR TITLE
feat: handle cookie consent

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ const path = require("path");
 const { CONFIG } = require("./config");
 const { DriverScraper } = require("./drivers");
 const { ConstructorScraper } = require("./constructors");
-const { closePopup } = require("./utils");
+const { closePopup, handleCookieConsent } = require("./utils");
 
 // Instantiate scrapers so their internal data structures can be reused
 const driverScraper = new DriverScraper();
@@ -34,6 +34,7 @@ async function main() {
     console.log(`📊 Target: ${CONFIG.DRIVER_URL}`);
     await page.goto(CONFIG.DRIVER_URL, { waitUntil: "load" });
     await page.waitForTimeout(CONFIG.DELAYS.PAGE_LOAD);
+    await handleCookieConsent(page);
     await closePopup(page);
 
     const driverElements = await driverScraper.extractListData(page);
@@ -42,6 +43,7 @@ async function main() {
     console.log(`📊 Target: ${CONFIG.CONSTRUCTOR_URL}`);
     await page.goto(CONFIG.CONSTRUCTOR_URL, { waitUntil: "load" });
     await page.waitForTimeout(CONFIG.DELAYS.PAGE_LOAD);
+    await handleCookieConsent(page);
     await closePopup(page);
 
     const constructorElements = await constructorScraper.extractListData(page);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,23 @@
 const { CONFIG } = require("./config");
 
+async function handleCookieConsent(page) {
+  try {
+    const iframeElement = await page.$("#sp_message_iframe_1336275");
+    if (iframeElement) {
+      const iframe = await iframeElement.contentFrame();
+      if (iframe) {
+        await iframe.click('button:has-text("Essential only cookies")', {
+          timeout: 3000,
+        });
+        console.log("✅ Cookie consent handled");
+        await page.waitForTimeout(2000);
+      }
+    }
+  } catch (e) {
+    console.log("ℹ️  No cookie consent dialog");
+  }
+}
+
 async function closePopup(page, delays = CONFIG.DELAYS) {
   // Helper to click a visible button by accessible name
   const clickByRole = async (scope, nameRe, timeout = 2000) => {
@@ -120,4 +138,4 @@ async function emergencyClosePopup(page) {
   }
 }
 
-module.exports = { closePopup, emergencyClosePopup };
+module.exports = { closePopup, emergencyClosePopup, handleCookieConsent };

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,7 +1,46 @@
 /* eslint-env jest */
 /* global jest, describe, test, expect */
-const { closePopup, emergencyClosePopup } = require("../src/utils");
+const {
+  closePopup,
+  emergencyClosePopup,
+  handleCookieConsent,
+} = require("../src/utils");
 const { CONFIG } = require("../src/config");
+
+describe("handleCookieConsent", () => {
+  test("clicks essential only cookies button in iframe", async () => {
+    const iframe = { click: jest.fn().mockResolvedValue() };
+    const iframeElement = {
+      contentFrame: jest.fn().mockResolvedValue(iframe),
+    };
+    const page = {
+      $: jest.fn().mockResolvedValue(iframeElement),
+      waitForTimeout: jest.fn(),
+    };
+
+    await handleCookieConsent(page);
+
+    expect(page.$).toHaveBeenCalledWith("#sp_message_iframe_1336275");
+    expect(iframeElement.contentFrame).toHaveBeenCalled();
+    expect(iframe.click).toHaveBeenCalledWith(
+      'button:has-text("Essential only cookies")',
+      { timeout: 3000 },
+    );
+    expect(page.waitForTimeout).toHaveBeenCalledWith(2000);
+  });
+
+  test("does nothing if iframe is missing", async () => {
+    const page = {
+      $: jest.fn().mockResolvedValue(null),
+      waitForTimeout: jest.fn(),
+    };
+
+    await handleCookieConsent(page);
+
+    expect(page.$).toHaveBeenCalledWith("#sp_message_iframe_1336275");
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+});
 
 describe("closePopup", () => {
   test("clicks reject in Sourcepoint frame when available", async () => {
@@ -36,11 +75,9 @@ describe("closePopup", () => {
       getByRole: jest.fn().mockReturnValue({ first: () => failingButton }),
     };
     const otFrame = {
-      locator: jest
-        .fn()
-        .mockReturnValue({
-          first: () => ({ isVisible: jest.fn().mockResolvedValue(false) }),
-        }),
+      locator: jest.fn().mockReturnValue({
+        first: () => ({ isVisible: jest.fn().mockResolvedValue(false) }),
+      }),
     };
     const genericButton = {
       waitFor: jest.fn().mockResolvedValue(),
@@ -51,11 +88,9 @@ describe("closePopup", () => {
         .fn()
         .mockReturnValueOnce(spFrame)
         .mockReturnValueOnce(otFrame),
-      locator: jest
-        .fn()
-        .mockReturnValue({
-          first: () => ({ isVisible: jest.fn().mockResolvedValue(false) }),
-        }),
+      locator: jest.fn().mockReturnValue({
+        first: () => ({ isVisible: jest.fn().mockResolvedValue(false) }),
+      }),
       getByRole: jest.fn().mockReturnValue({ first: () => genericButton }),
       waitForTimeout: jest.fn(),
       keyboard: { press: jest.fn() },
@@ -78,22 +113,18 @@ describe("closePopup", () => {
       getByRole: jest.fn().mockReturnValue({ first: () => failingButton }),
     };
     const otFrame = {
-      locator: jest
-        .fn()
-        .mockReturnValue({
-          first: () => ({ isVisible: jest.fn().mockResolvedValue(false) }),
-        }),
+      locator: jest.fn().mockReturnValue({
+        first: () => ({ isVisible: jest.fn().mockResolvedValue(false) }),
+      }),
     };
     const page = {
       frameLocator: jest
         .fn()
         .mockReturnValueOnce(spFrame)
         .mockReturnValueOnce(otFrame),
-      locator: jest
-        .fn()
-        .mockReturnValue({
-          first: () => ({ isVisible: jest.fn().mockResolvedValue(false) }),
-        }),
+      locator: jest.fn().mockReturnValue({
+        first: () => ({ isVisible: jest.fn().mockResolvedValue(false) }),
+      }),
       getByRole: jest.fn().mockReturnValue({ first: () => failingButton }),
       waitForTimeout: jest.fn(),
       keyboard: { press: jest.fn() },


### PR DESCRIPTION
## Summary
- add handleCookieConsent helper to click Sourcepoint 'Essential only cookies' button
- invoke handleCookieConsent after each navigation in main scraper
- test cookie consent handling alongside popup utilities

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd5a92e3cc832aa92eab833754917b